### PR TITLE
マグマバケツでRefuel

### DIFF
--- a/scripts/handlers.lua
+++ b/scripts/handlers.lua
@@ -36,15 +36,7 @@ local function refuel(original_nav, chest_station_nav, target_fuel_level)
         error("Insufficient blank slot to refuel")
     end
 
-    turtle.select(blank_slot)
-    while turtle.getFuelLevel() < target_fuel_level do
-        if turtle.suck(1) then
-            turtle.refuel()
-        else
-            print("failed to suck items, continue")
-            break
-        end
-    end
+    Refuel2(target_fuel_level)
 end
 
 -- 燃料補給ハンドラを作成

--- a/scripts/handlers.lua
+++ b/scripts/handlers.lua
@@ -28,10 +28,12 @@ end
 -- original_nav: Navigation = 現在位置
 local function refuel(original_nav, chest_station_nav, target_fuel_level)
     local blank_slot = Find_blank_slot()
-    print("blank slot "..blank_slot)
-    if blank_slot == 0 then
+    if not(blank_slot) then
         Free_slots(original_nav, chest_station_nav)
         blank_slot = Find_blank_slot()
+    end
+    if not(blank_slot) then
+        error("Insufficient blank slot to refuel")
     end
 
     turtle.select(blank_slot)

--- a/scripts/util.lua
+++ b/scripts/util.lua
@@ -40,20 +40,29 @@ function Drop_all(ignores)
     turtle.select(selected)
 end
 
-function Select_first_slot_of(item_id)
+function Find_first_slot_of(item_id)
     local info = turtle.getItemDetail()
     if info and info.name == item_id then
         return turtle.getSelectedSlot()
     end
 
     for i = 1, SLOTS_MAX do
-        turtle.select(i)
-        local info = turtle.getItemDetail()
+        local info = turtle.getItemDetail(i)
         if info and info.name == item_id then
             return i
         end
     end
     return nil
+end
+
+function Select_first_slot_of(item_id)
+    local slot = Find_first_slot_of(item_id)
+    if slot then
+        turtle.select(slot)
+        return slot
+    else
+        return nil
+    end
 end
 
 function Try(fn, ntimes)

--- a/scripts/util.lua
+++ b/scripts/util.lua
@@ -13,7 +13,7 @@ function Find_blank_slot()
             return i
         end
     end
-    return 0
+    return nil
 end
 
 function Is_slots_full()

--- a/scripts/util.lua
+++ b/scripts/util.lua
@@ -76,3 +76,53 @@ function Try(fn, ntimes)
     end
     return false
 end
+
+-- 目の前にあるチェストから燃料補給
+-- マグマバケツ対応版
+function Refuel2(target_fuel_level)
+    local ITEM_LAVA_BUCKET = "minecraft:lava_bucket"
+    local ITEM_BUCKET = "minecraft:bucket"
+
+    local target_fuel_level = target_fuel_level or 1000
+
+    while true do
+        local working_slot = Find_blank_slot()
+
+        if not(working_slot) then
+            print("Insufficient blank slots")
+            return false
+        end
+
+        if turtle.getFuelLevel() >= target_fuel_level then
+            print("Target fuel level is already satisfied")
+            return true
+        end
+
+        if turtle.getFuelLevel() == turtle.getFuelLimit() then
+            print("Fuel limit reached")
+            return true
+        end
+
+        turtle.select(working_slot)
+        if turtle.suck() then
+            local item = turtle.getItemDetail()
+            if item.name == ITEM_LAVA_BUCKET then
+                -- lava
+                local empty_buckets_slot = Find_first_slot_of(ITEM_BUCKET) or Find_blank_slot()
+                if empty_buckets_slot then
+                    turtle.refuel()
+                    turtle.transferTo(empty_buckets_slot)
+                else
+                    print("Insufficient blank slots for lava bucket refuel, skip.")
+                end
+            else
+                -- not lava
+                turtle.refuel()
+            end
+        else
+            print("No more fuel to suck")
+            return true
+        end
+    end
+    return true
+end


### PR DESCRIPTION
- 目の前にあるチェストから燃料補給
- マグマバケツ対応版
- 空きスロット不足のエラーハンドリング
- 空きバケツは持っておいてあとで鉱石用チェストに入れる